### PR TITLE
Publish to NPM and add this as a CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,13 +5,18 @@ search.maven.org
 
 ## Installation 
 
-Prerequisite: node 10.9.0 or newer should be installed
+Prerequisite: node `10.9.0` or newer should be installed.
 
-Installation:
+<!-- Installation:
  - download the latest release from the [releases page](https://github.com/erosb/mvn-search/releases)
  - extract the zip
  - optional: set up the following alias: `alias mvn-search="node <ZIP-EXTRACTION-DIR>/index.js"`
- 
+  -->
+
+```bash
+npm install -g mvn-search
+```
+
 ## Usage: `mvn-search <query-string>`
 
 This will list the found artifacts with their latest version numbers. After selecting the coordinates the tool displays

--- a/bin/mvn-search
+++ b/bin/mvn-search
@@ -1,0 +1,4 @@
+#!/usr/bin/env node
+
+require = require('esm')(module /*, options*/);
+require('../src/index').search(process.argv);

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "mvn-search",
+  "name": "@erosb/mvn-search",
   "version": "0.0.2",
   "lockfileVersion": 1,
   "requires": true,
@@ -117,6 +117,11 @@
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
       "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
+    },
+    "esm": {
+      "version": "3.2.25",
+      "resolved": "https://registry.npmjs.org/esm/-/esm-3.2.25.tgz",
+      "integrity": "sha512-U1suiZ2oDVWv4zPO56S0NcR5QriEahGtdN2OR6FiOG4WJvcjBVFB0qI4+eKoWFH483PKGuLuu6V8Z4T5g63UVA=="
     },
     "execa": {
       "version": "1.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "mvn-search",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mvn-search",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "description": "",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,16 +1,34 @@
 {
-  "name": "mvn-search",
+  "name": "@erosb/mvn-search",
   "version": "0.0.2",
-  "description": "",
-  "main": "index.js",
+  "description": "CLI to search the Maven dependencies",
+  "main": "src/index.js",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "bin": {
+    "@erosb/mvn-search": "bin/mvn-search",
+    "mvn-search": "bin/mvn-search"
+  },
+  "publishConfig": {
+    "access": "public"
+  },
+  "keywords": [
+    "cli",
+    "mvn",
+    "search",
+    "java",
+    "dependency"
+  ],
+  "repository": {
+    "url": "https://github.com/erosb/mvn-search"
   },
   "author": "Bence Eros",
   "license": "MIT",
   "dependencies": {
     "clipboardy": "^2.1.0",
     "copy-to-clipboard": "^3.2.0",
+    "esm": "^3.2.25",
     "inquirer": "^7.0.0",
     "node-fetch": "^2.6.0"
   }

--- a/src/index.js
+++ b/src/index.js
@@ -21,7 +21,7 @@ function versionSearchResponseArrived(resp) {
         console.log("no result");
         return;
     }
-    needle = hits[0];
+    let needle = hits[0];
     const filtered = lastSearchResults.filter(e => e.groupId === needle.g && e.artifactId === needle.a);
     if (filtered.length === 0) {
         console.warn(`could not find ${needle.groupId}:${needle.artifactId}`);
@@ -123,8 +123,10 @@ function startSearch(searchTerm) {
     .then(mvnSearchResponseArrived);
 }
 
-if (process.argv.length < 3 || process.argv[2].trim() === "") {
+export function search(argv) {
+    if (argv.length < 3 || argv[2].trim() === "") {
     newSearch();
-} else {
-    startSearch(process.argv[2]);
+    } else {
+        startSearch(argv[2]);
+    }
 }


### PR DESCRIPTION
This is in very early stage and I have tried to make this run like a CLI so that we can just do `npm install -g mvn-search` and this will add `mvn-search` to command-line.


If you are merging this request, you will have to also plan to publish to NPM repository. Verify the details on `package.json` before publishing it to npm repository. and let me know if you need any help in publishing.

Demo using `npm link` is provided here [Demo Link](https://terminalizer.com/view/6376b1f14184)

This is an effort to address #2 